### PR TITLE
fix for opening/closing doors with Minetest 0.4.13

### DIFF
--- a/mods/doors/init.lua
+++ b/mods/doors/init.lua
@@ -121,7 +121,7 @@ function _doors.door_toggle(pos, clicker)
 	local def = minetest.registered_nodes[minetest.get_node(pos).name]
 	local name = def.door.name
 
-	if clicker and not minetest.check_player_privs(clicker, "protection_bypass") then
+	if clicker and not minetest.check_player_privs(clicker:get_player_name(), {"protection_bypass"}) then
 		local owner = meta:get_string("doors_owner")
 		if owner ~= "" then
 			if clicker:get_player_name() ~= owner then


### PR DESCRIPTION
Hi

I warn you I know nothing about lua language, and minetes's API.

This fixed an exception with minetest 0.4.13 when I at tempt to open a door.
